### PR TITLE
Add mouse constants and properties

### DIFF
--- a/data/constants.json
+++ b/data/constants.json
@@ -30,6 +30,8 @@
   "RIGHT_ARROW": false,
   "TAB": false,
   "UP_ARROW": false,
+  "LEFT": false,
+  "RIGHT": false,
   "ADD": false,
   "DARKEST": false,
   "OVERLAY": false,

--- a/data/properties.json
+++ b/data/properties.json
@@ -76,6 +76,8 @@
   "height": false,
   "mouseX": false,
   "mouseY": false,
+  "pmouseX": false,
+  "pmouseY": false,
   "pixels": false,
   "key": false
 }


### PR DESCRIPTION
Added missing constants and properties for mouse buttons (LEFT, RIGHT) and previous mouse coordinates (pmouseX, pmouseY)